### PR TITLE
YBE-1582 Make libpng prefixable to avoid conflicts with system version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,15 @@ if(NOT CMAKE_VERSION VERSION_LESS 3.12)
   # environment variable.
   cmake_policy(SET CMP0074 NEW)
 endif()
+
 hunter_add_package(ZLIB)
 find_package(ZLIB CONFIG REQUIRED)
+
+# This should have been found by the find_package above
+# but for some reason it doesn't get done when building libpng with prefixed APIs
+if (NOT ZLIB_INCLUDE_DIR)
+    set(ZLIB_INCLUDE_DIR "${ZLIB_ROOT}/include")
+endif()
 
 # COMMAND LINE OPTIONS
 option(PNG_TESTS  "Build libpng tests" YES)
@@ -62,8 +69,6 @@ option(PNG_MULTIARCH "Support multiple architectures within the same project" OF
 
 set(PNG_PREFIX "" CACHE STRING "Prefix to add to the API function names")
 set(DFA_XTRA "" CACHE FILEPATH "File containing extra configuration settings")
-
-option(PNG_DISABLE_AWK "Disable AWK based scripts code generation" YES)
 
 if(PNG_HARDWARE_OPTIMIZATIONS)
 
@@ -273,7 +278,7 @@ find_program(AWK NAMES gawk awk)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 include(CMakeParseArguments)
-if(NOT AWK OR ANDROID OR PNG_DISABLE_AWK)
+if(NOT AWK)
   # No awk available to generate sources; use pre-built pnglibconf.h
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
@@ -465,7 +470,7 @@ set(libpng_private_hdrs
   pnginfo.h
   pngstruct.h
 )
-if(AWK AND NOT ANDROID AND NOT PNG_DISABLE_AWK)
+if(AWK)
   list(APPEND libpng_private_hdrs "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h")
 endif()
 set(libpng_sources

--- a/scripts/genout.cmake.in
+++ b/scripts/genout.cmake.in
@@ -71,6 +71,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
                           "-DPNG_BUILDING_SYMBOL_TABLE"
                           ${PNG_PREFIX_DEF}
                           "${INPUT}"
+                  COMMAND_ECHO STDOUT
                   OUTPUT_FILE "${OUTPUT}.tf1"
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE CPP_FAIL)
@@ -80,6 +81,7 @@ if ("${INPUTEXT}" STREQUAL ".c" AND "${OUTPUTEXT}" STREQUAL ".out")
 
   execute_process(COMMAND "${AWK}" -f "${SRCDIR}/scripts/dfn.awk"
                           "out=${OUTPUT}.tf2" "${OUTPUT}.tf1"
+                  COMMAND_ECHO STDOUT
                   WORKING_DIRECTORY "${BINDIR}"
                   RESULT_VARIABLE AWK_FAIL)
   if(AWK_FAIL)


### PR DESCRIPTION
The `libpng` library proper has added the ability to add custom prefixes for its public APIs a while ago, and it's actually quite easy to use (basically a one-liner, specifying prefix as a PNG_PREFIX argument - which is also in the accompanying PR https://github.com/YOU-i-Labs/YouiPlatform/pull/17846#pullrequestreview-1021034385).

Yet, when I tested our libpng fork, it turned out that while specifying the prefix via the `configure` script worked fine, the `cmake` alternative didn't work at all. I tested it with the pure upstream and it all worked in both modes, off the tip and with the version we forked from as well.

After some bisecting, I arrived at https://github.com/YOU-i-Labs/libpng/commit/25399ab454a0f422a9d7ffff0d8377e87d01c63f which both hunterified the libpng for us AND broke its prefixing functionality.

The subject of this PR is essentially to restore the ability to add prefixes while keeping the hunter integration, of course.
