### PR TITLE
Use pre-built pnglibconf.h if PNG_PREFIX is not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,7 +278,7 @@ find_program(AWK NAMES gawk awk)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 include(CMakeParseArguments)
-if(NOT AWK)
+if(NOT AWK OR NOT PNG_PREFIX)
   # No awk available to generate sources; use pre-built pnglibconf.h
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
@@ -470,7 +470,7 @@ set(libpng_private_hdrs
   pnginfo.h
   pngstruct.h
 )
-if(AWK)
+if(AWK AND PNG_PREFIX)
   list(APPEND libpng_private_hdrs "${CMAKE_CURRENT_BINARY_DIR}/pngprefix.h")
 endif()
 set(libpng_sources


### PR DESCRIPTION
The presence of a defined PNG_PREFIX controls whether API prefixing should be enabled or disabled.