### PR TITLE
YBE-1582 Don't slip into no-prefix libpng mode silently on awk missing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -278,8 +278,11 @@ find_program(AWK NAMES gawk awk)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 include(CMakeParseArguments)
-if(NOT AWK OR NOT PNG_PREFIX)
-  # No awk available to generate sources; use pre-built pnglibconf.h
+
+if(PNG_PREFIX AND NOT AWK)
+    message(FATAL_ERROR "libpng API prefixing is requested but awk/gawk tools are unavailable to do file generation")
+elseif(NOT PNG_PREFIX)
+  # Use pre-built pnglibconf.h
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/scripts/pnglibconf.h.prebuilt
                  ${CMAKE_CURRENT_BINARY_DIR}/pnglibconf.h)
   add_custom_target(genfiles) # Dummy


### PR DESCRIPTION
There's no real point in ignoring the awk absence when API prefixing is
requested since the caller will use prefixed API names (which are
unavailable in the un-prefixed libpng build) anyway, and this will
result in build errors.